### PR TITLE
Use batteryless welder in tests, revert battery with welder test item change

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -4794,34 +4794,6 @@
     "melee_damage": { "bash": 1 }
   },
   {
-    "id": "welder",
-    "type": "TOOL",
-    "copy-from": "welder",
-    "name": { "str": "arc welder" },
-    "description": "Copy of arc welder that still uses batteries.",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "magazine_well": "500 ml",
-        "default_magazine": "medium_storage_battery",
-        "item_restriction": [
-          "medium_storage_battery",
-          "medium_battery_cell",
-          "medium_plus_battery_cell",
-          "medium_disposable_cell",
-          "medium_atomic_battery_cell",
-          "heavy_battery_cell",
-          "heavy_plus_battery_cell",
-          "heavy_disposable_cell",
-          "heavy_atomic_battery_cell",
-          "small_storage_battery",
-          "large_storage_battery",
-          "storage_battery"
-        ]
-      }
-    ]
-  },
-  {
     "id": "vac_mold",
     "type": "TOOL",
     "copy-from": "vac_mold",

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -96,9 +96,6 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         // tools.push_back( tool_with_ammo( "welder", 10000 ) );
 
         item welder( "welder" );
-        item welder_mag( welder.magazine_default() );
-        welder_mag.ammo_set( welder_mag.ammo_default(), 1000 );
-        welder.put_in( welder_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( welder );
 
         tools.emplace_back( "goggles_welding" );
@@ -129,9 +126,6 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         std::vector<item> tools;
 
         item welder( "welder" );
-        item welder_mag( welder.magazine_default() );
-        welder_mag.ammo_set( welder_mag.ammo_default(), 1000 );
-        welder.put_in( welder_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( welder );
 
         tools.emplace_back( "hammer" );
@@ -143,9 +137,6 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         std::vector<item> tools;
 
         item welder( "welder" );
-        item welder_mag( welder.magazine_default() );
-        welder_mag.ammo_set( welder_mag.ammo_default(), 500 );
-        welder.put_in( welder_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( welder );
 
         tools.emplace_back( "goggles_welding" );
@@ -175,9 +166,6 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         std::vector<item> tools;
 
         item welder( "welder" );
-        item welder_mag( welder.magazine_default() );
-        welder_mag.ammo_set( welder_mag.ammo_default(), 500 );
-        welder.put_in( welder_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( welder );
 
         tools.emplace_back( "goggles_welding" );


### PR DESCRIPTION
Battery doesn't need to be loaded at all for pluggable tools after https://github.com/CleverRaven/Cataclysm-DDA/pull/70029, it automates the setup for them.